### PR TITLE
chore: remove debug print

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/ballon.dart
+++ b/lib/src/ballon.dart
@@ -52,7 +52,6 @@ class _BallonState extends State<_Ballon> {
       if (renderBox == null) return;
       final Size size = renderBox.size;
       final position = renderBox.localToGlobal(Offset.zero);
-      debugPrint("position : ${position.dx},${position.dy}, Size: ${renderBox.size}");
 
       if (_lastSizeNotified == null ||
           _lastSizeNotified!.size != size ||

--- a/lib/src/obfuscate_tooltip_item.dart
+++ b/lib/src/obfuscate_tooltip_item.dart
@@ -34,7 +34,6 @@ class ObfuscateTooltipItemState extends State<ObfuscateTooltipItem> with Widgets
     _intervalSubscription = Stream.periodic(Duration(seconds: 1)).listen((event) {
       final currentPositionSize = getPositionAndSize();
       if (_lastPositionSize != currentPositionSize) {
-        debugPrint("Notifying change");
         _notifySizeChange(widget.tooltipKeys);
       }
       _lastPositionSize = currentPositionSize;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
* pub get + remove `debugPrint` that pollutes console log